### PR TITLE
Dark theme support

### DIFF
--- a/src/DarkThemeProvider.jsx
+++ b/src/DarkThemeProvider.jsx
@@ -1,0 +1,51 @@
+import React, { useEffect, useState } from 'react';
+
+import { useMediaQuery } from '@mui/material';
+import { createTheme, responsiveFontSizes, ThemeProvider } from '@mui/material/styles';
+import { grey } from '@mui/material/colors';
+
+import createPersistedState from 'use-persisted-state';
+
+const useThemePrefs = createPersistedState('themePref');
+
+const validateTheme = themePrefs => (['light', 'dark'].includes(themePrefs) ? themePrefs : 'light');
+
+const DarkThemeProvider = ({ children }) => {
+  const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
+  const [themePrefs] = useThemePrefs('system');
+  const [mode, setMode] = useState();
+
+  useEffect(() => {
+    if (themePrefs === 'system') {
+      setMode(prefersDarkMode ? 'dark' : 'light');
+      return;
+    }
+    setMode(validateTheme(themePrefs));
+  }, [themePrefs, prefersDarkMode]);
+
+  const theme = React.useMemo(
+    () =>
+      responsiveFontSizes(
+        createTheme({
+          palette: {
+            mode,
+            primary: {
+              main: '#adb31b',
+              contrastText: '#fff',
+              fg: mode === 'dark' ? '#ffffff' : grey[600],
+              bg: mode === 'dark' ? '#000000' : '#ffffff',
+            },
+            secondary: {
+              main: '#f50057',
+              bg: mode === 'dark' ? '#333333' : '#f5f5f5',
+            },
+          },
+        }),
+      ),
+    [mode],
+  );
+
+  return <ThemeProvider theme={theme}>{children}</ThemeProvider>;
+};
+
+export default DarkThemeProvider;

--- a/src/components/DayHeader.jsx
+++ b/src/components/DayHeader.jsx
@@ -22,7 +22,7 @@ const useStyles = makeStyles(theme => ({
   },
 
   highlight: {
-    backgroundColor: emphasize(theme.palette.primary.main, 0.25),
+    backgroundColor: emphasize(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0 : 0.25),
   },
 }));
 

--- a/src/components/Legend.jsx
+++ b/src/components/Legend.jsx
@@ -19,8 +19,7 @@ const useLegendStyles = makeStyles(theme => ({
     zIndex: 1,
     transform: ({ hidden }) => `translateX(-50%) translateY(${hidden ? 100 : 0}%)`,
     transition: theme.transitions.create('transform'),
-
-    background: 'rgba(255, 255, 255, 0.8)',
+    background: alpha(theme.palette.primary.bg, 0.8),
     padding: theme.spacing(0.5, 1, 1),
     borderRadius: theme.shape.borderRadius,
     boxShadow: theme.shadows[1],

--- a/src/components/Plan.jsx
+++ b/src/components/Plan.jsx
@@ -9,7 +9,7 @@ import { TransformWrapper, TransformComponent } from 'react-zoom-pan-pinch';
 import createPersistedState from 'use-persisted-state';
 
 import { Box, Fab, Tooltip } from '@mui/material';
-import { alpha } from '@mui/material/styles';
+import { alpha, lighten } from '@mui/material/styles';
 import makeStyles from '@mui/styles/makeStyles';
 import withStyles from '@mui/styles/withStyles';
 import usePlans from '../hooks/usePlans';
@@ -40,19 +40,24 @@ const useStyles = makeStyles(theme => ({
   planWrapper: {
     position: 'relative',
   },
-  plan: {},
+  plan: {
+    filter: theme.palette.mode === 'dark' ? 'invert(100%)' : 'invert(0%)',
+  },
 
   spot: {
     position: 'absolute',
     transform: 'translate(-50%, -50%)',
     border: '2px solid transparent',
-    backgroundColor: 'white',
-    color: theme.palette.grey[600],
+    backgroundColor: theme.palette.primary.bg,
+    color: theme.palette.primary.fg,
     textTransform: 'none',
     opacity: 0.3,
     whiteSpace: 'nowrap',
     textOverflow: 'ellipsis',
     overflow: 'hidden',
+    '&:hover': {
+      backgroundColor: alpha(theme.palette.primary.fg, 0.25),
+    }
   },
 
   locked: {
@@ -69,7 +74,7 @@ const useStyles = makeStyles(theme => ({
 
   occupied: {
     backgroundColor: alpha(theme.palette.primary.main, 0.25),
-    color: theme.palette.primary.main,
+    color: lighten(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.75 : 0),
     opacity: 1,
     cursor: 'default',
     boxShadow: 'none',

--- a/src/components/Plan.jsx
+++ b/src/components/Plan.jsx
@@ -57,7 +57,7 @@ const useStyles = makeStyles(theme => ({
     overflow: 'hidden',
     '&:hover': {
       backgroundColor: alpha(theme.palette.primary.fg, 0.25),
-    }
+    },
   },
 
   locked: {

--- a/src/components/PresenceCalendar.jsx
+++ b/src/components/PresenceCalendar.jsx
@@ -78,7 +78,7 @@ const useStyles = makeStyles(theme => ({
     flex: 1,
     display: 'flex',
 
-    background: '#f5f5f5',
+    background: theme.palette.secondary.bg,
     fontSize: theme.typography.pxToRem(10),
     padding: theme.spacing(1),
     '&:last-child': {

--- a/src/components/UserMenu.jsx
+++ b/src/components/UserMenu.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import createPersistedState from 'use-persisted-state';
 
-import { IconButton, Button } from '@mui/material';
-import { Person } from '@mui/icons-material';
+import { IconButton, Button, Menu, MenuItem, ToggleButtonGroup, ToggleButton, Tooltip, Typography } from '@mui/material';
+import { Person, DarkMode, WbSunny, SettingsBrightness, ArrowDropDown } from '@mui/icons-material';
 import makeStyles from '@mui/styles/makeStyles';
 
 const useTriState = createPersistedState('tri');
+const useThemePrefs = createPersistedState('themePref');
 
 const useStyles = makeStyles(theme => {
   const maxWidth = mq => `@media (max-width: ${theme.breakpoints.values[mq]}px)`;
@@ -14,6 +15,13 @@ const useStyles = makeStyles(theme => {
   return {
     icon: {
       [minWidth('md')]: { display: 'none' },
+    },
+    themeIcon: {
+      marginRight: 7,
+      fill: theme.palette.mode === 'dark' ? 'white' : 'black',
+    },
+    themeLabel: {
+      textTransform: 'none',
     },
     text: {
       textTransform: 'none',
@@ -25,10 +33,20 @@ const useStyles = makeStyles(theme => {
 
 const UserMenu = () => {
   const [tri, setTri] = useTriState();
+  const [themePrefs, setThemePrefs] = useThemePrefs();
 
   const classes = useStyles();
 
-  const handleClick = () => setTri('');
+  const handleChangeTri = () => setTri('');
+
+  const [anchorEl, setAnchorEl] = React.useState(null);
+  const open = Boolean(anchorEl);
+  const handleClick = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
 
   return (
     <>
@@ -47,9 +65,41 @@ const UserMenu = () => {
         onClick={handleClick}
         color="primary"
         startIcon={<Person />}
+        endIcon={<ArrowDropDown />}
       >
-        {tri} (changer)
+        {tri}
       </Button>
+      <Menu
+        id="basic-menu"
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        MenuListProps={{
+          'aria-labelledby': 'basic-button',
+        }}
+      >
+        <Typography style={{ paddingLeft: 10}} variant="overline" display="block" gutterBottom>
+          Thème
+        </Typography>
+        <ToggleButtonGroup
+          size="small" 
+          value={themePrefs}
+          exclusive
+          style={{ paddingLeft: 10, paddingRight: 10, marginBottom: 10 }}
+          fullWidth
+        >
+          <ToggleButton onClick={() => setThemePrefs('dark')} value="dark">
+            <DarkMode className={classes.themeIcon} /><span className={classes.themeLabel}>Sombre</span>
+          </ToggleButton>
+          <ToggleButton onClick={() => setThemePrefs('system')} value="system">
+            <SettingsBrightness className={classes.themeIcon} /><span className={classes.themeLabel}>Système</span>
+          </ToggleButton>
+          <ToggleButton onClick={() => setThemePrefs('light')} value="light">
+            <WbSunny className={classes.themeIcon} /><span className={classes.themeLabel}>Clair</span>
+          </ToggleButton>
+        </ToggleButtonGroup>
+        <MenuItem onClick={handleChangeTri}>Changer trigramme</MenuItem>
+      </Menu>
     </>
   );
 };

--- a/src/components/UserMenu.jsx
+++ b/src/components/UserMenu.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import createPersistedState from 'use-persisted-state';
 
-import { IconButton, Button, Menu, MenuItem, ToggleButtonGroup, ToggleButton, Tooltip, Typography } from '@mui/material';
+import { IconButton, Button, Menu, MenuItem, ToggleButtonGroup, ToggleButton, Typography } from '@mui/material';
 import { Person, DarkMode, WbSunny, SettingsBrightness, ArrowDropDown } from '@mui/icons-material';
 import makeStyles from '@mui/styles/makeStyles';
 
@@ -18,7 +18,7 @@ const useStyles = makeStyles(theme => {
     },
     themeIcon: {
       marginRight: 7,
-      fill: theme.palette.mode === 'dark' ? 'white' : 'black',
+      fill: 'currentColor',
     },
     themeLabel: {
       textTransform: 'none',
@@ -33,7 +33,7 @@ const useStyles = makeStyles(theme => {
 
 const UserMenu = () => {
   const [tri, setTri] = useTriState();
-  const [themePrefs, setThemePrefs] = useThemePrefs();
+  const [themePrefs, setThemePrefs] = useThemePrefs('system');
 
   const classes = useStyles();
 
@@ -41,7 +41,7 @@ const UserMenu = () => {
 
   const [anchorEl, setAnchorEl] = React.useState(null);
   const open = Boolean(anchorEl);
-  const handleClick = (event) => {
+  const handleClick = event => {
     setAnchorEl(event.currentTarget);
   };
   const handleClose = () => {
@@ -78,24 +78,27 @@ const UserMenu = () => {
           'aria-labelledby': 'basic-button',
         }}
       >
-        <Typography style={{ paddingLeft: 10}} variant="overline" display="block" gutterBottom>
+        <Typography style={{ paddingLeft: 10 }} variant="overline" display="block" gutterBottom>
           Thème
         </Typography>
         <ToggleButtonGroup
-          size="small" 
+          size="small"
           value={themePrefs}
           exclusive
           style={{ paddingLeft: 10, paddingRight: 10, marginBottom: 10 }}
           fullWidth
         >
           <ToggleButton onClick={() => setThemePrefs('dark')} value="dark">
-            <DarkMode className={classes.themeIcon} /><span className={classes.themeLabel}>Sombre</span>
+            <DarkMode className={classes.themeIcon} />
+            <span className={classes.themeLabel}>Sombre</span>
           </ToggleButton>
           <ToggleButton onClick={() => setThemePrefs('system')} value="system">
-            <SettingsBrightness className={classes.themeIcon} /><span className={classes.themeLabel}>Système</span>
+            <SettingsBrightness className={classes.themeIcon} />
+            <span className={classes.themeLabel}>Système</span>
           </ToggleButton>
           <ToggleButton onClick={() => setThemePrefs('light')} value="light">
-            <WbSunny className={classes.themeIcon} /><span className={classes.themeLabel}>Clair</span>
+            <WbSunny className={classes.themeIcon} />
+            <span className={classes.themeLabel}>Clair</span>
           </ToggleButton>
         </ToggleButtonGroup>
         <MenuItem onClick={handleChangeTri}>Changer trigramme</MenuItem>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,7 +1,9 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 
 import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
+
+import createPersistedState from 'use-persisted-state';
 
 import {
   createTheme,
@@ -9,7 +11,7 @@ import {
   ThemeProvider,
   StyledEngineProvider,
 } from '@mui/material/styles';
-import { CssBaseline } from '@mui/material';
+import { CssBaseline, useMediaQuery } from '@mui/material';
 
 import { QueryClient, QueryClientProvider } from 'react-query';
 
@@ -18,8 +20,10 @@ import ArchivePage from './components/ArchivePage';
 
 import { version } from '../package.json';
 import TTCount from './components/TTCount';
+import { grey } from '@mui/material/colors';
 
 const { VITE_PROJECT_VERSION = version } = import.meta.env;
+
 
 if (typeof localStorage.VITE_PROJECT_VERSION === 'undefined' || localStorage.VITE_PROJECT_VERSION === null) {
   localStorage.setItem('VITE_PROJECT_VERSION', VITE_PROJECT_VERSION);
@@ -29,39 +33,67 @@ if (localStorage.VITE_PROJECT_VERSION !== VITE_PROJECT_VERSION) {
   localStorage.clear();
 }
 
-const theme = responsiveFontSizes(
-  createTheme({
-    palette: {
-      primary: {
-        main: '#adb31b',
-        contrastText: '#fff',
-      },
-      secondary: {
-        main: '#f50057',
-      },
-    },
-  }),
-);
+const useThemePrefs = createPersistedState('themePref');
 
 const queryClient = new QueryClient();
 
+function App() {
+  const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
+  const [themePrefs, setThemePrefs] = useThemePrefs();
+  const [currentTheme, setCurrentTheme] = useState();
+
+  useEffect(() => {
+    if (themePrefs === "dark") {
+      setCurrentTheme('dark');
+    } else if (themePrefs === 'light') {
+      setCurrentTheme('light');
+    } else {
+      setCurrentTheme(prefersDarkMode ? 'dark' : 'light');
+      setThemePrefs('system');
+    }
+  }, [themePrefs, prefersDarkMode])
+
+  const theme = React.useMemo(
+    () =>
+      responsiveFontSizes(createTheme({
+        palette: {
+          mode: currentTheme,
+          primary: {
+            main: '#adb31b',
+            contrastText: '#fff',
+            fg: currentTheme === 'dark' ? '#ffffff' : grey[600],
+            bg: currentTheme === 'dark' ? '#000000' : '#ffffff',
+          },
+          secondary: {
+            main: '#f50057',
+            bg: currentTheme === 'dark' ? '#333333' : '#f5f5f5',
+          },
+        },
+      })),
+    [currentTheme],
+  );
+  return (
+    <React.StrictMode>
+      <QueryClientProvider client={queryClient}>
+        <StyledEngineProvider injectFirst>
+          <ThemeProvider theme={theme}>
+            <CssBaseline />
+            <Router>
+              <Switch>
+                <Route path="/tt"><TTCount /></Route>
+                <Route path={['/', '/:place', '/:place/:day']} exact><PresencePage /></Route>
+                <Route path="/archives"><ArchivePage /></Route>
+                <Route path="*">Error 404</Route>
+              </Switch>
+            </Router>
+          </ThemeProvider>
+        </StyledEngineProvider>
+      </QueryClientProvider>
+    </React.StrictMode>
+  )
+}
+
 ReactDOM.render(
-  <React.StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <StyledEngineProvider injectFirst>
-        <ThemeProvider theme={theme}>
-          <CssBaseline />
-          <Router>
-            <Switch>
-              <Route path="/tt"><TTCount /></Route>
-              <Route path={['/', '/:place', '/:place/:day']} exact><PresencePage /></Route>
-              <Route path="/archives"><ArchivePage /></Route>
-              <Route path="*">Error 404</Route>
-            </Switch>
-          </Router>
-        </ThemeProvider>
-      </StyledEngineProvider>
-    </QueryClientProvider>
-  </React.StrictMode>,
+  <App />,
   document.getElementById('root'),
 );

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,17 +1,12 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import ReactDOM from 'react-dom';
 
 import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
 
-import createPersistedState from 'use-persisted-state';
-
 import {
-  createTheme,
-  responsiveFontSizes,
-  ThemeProvider,
   StyledEngineProvider,
 } from '@mui/material/styles';
-import { CssBaseline, useMediaQuery } from '@mui/material';
+import { CssBaseline } from '@mui/material';
 
 import { QueryClient, QueryClientProvider } from 'react-query';
 
@@ -20,10 +15,9 @@ import ArchivePage from './components/ArchivePage';
 
 import { version } from '../package.json';
 import TTCount from './components/TTCount';
-import { grey } from '@mui/material/colors';
+import DarkThemeProvider from './DarkThemeProvider';
 
 const { VITE_PROJECT_VERSION = version } = import.meta.env;
-
 
 if (typeof localStorage.VITE_PROJECT_VERSION === 'undefined' || localStorage.VITE_PROJECT_VERSION === null) {
   localStorage.setItem('VITE_PROJECT_VERSION', VITE_PROJECT_VERSION);
@@ -33,67 +27,25 @@ if (localStorage.VITE_PROJECT_VERSION !== VITE_PROJECT_VERSION) {
   localStorage.clear();
 }
 
-const useThemePrefs = createPersistedState('themePref');
-
 const queryClient = new QueryClient();
 
-function App() {
-  const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
-  const [themePrefs, setThemePrefs] = useThemePrefs();
-  const [currentTheme, setCurrentTheme] = useState();
-
-  useEffect(() => {
-    if (themePrefs === "dark") {
-      setCurrentTheme('dark');
-    } else if (themePrefs === 'light') {
-      setCurrentTheme('light');
-    } else {
-      setCurrentTheme(prefersDarkMode ? 'dark' : 'light');
-      setThemePrefs('system');
-    }
-  }, [themePrefs, prefersDarkMode])
-
-  const theme = React.useMemo(
-    () =>
-      responsiveFontSizes(createTheme({
-        palette: {
-          mode: currentTheme,
-          primary: {
-            main: '#adb31b',
-            contrastText: '#fff',
-            fg: currentTheme === 'dark' ? '#ffffff' : grey[600],
-            bg: currentTheme === 'dark' ? '#000000' : '#ffffff',
-          },
-          secondary: {
-            main: '#f50057',
-            bg: currentTheme === 'dark' ? '#333333' : '#f5f5f5',
-          },
-        },
-      })),
-    [currentTheme],
-  );
-  return (
-    <React.StrictMode>
-      <QueryClientProvider client={queryClient}>
-        <StyledEngineProvider injectFirst>
-          <ThemeProvider theme={theme}>
-            <CssBaseline />
-            <Router>
-              <Switch>
-                <Route path="/tt"><TTCount /></Route>
-                <Route path={['/', '/:place', '/:place/:day']} exact><PresencePage /></Route>
-                <Route path="/archives"><ArchivePage /></Route>
-                <Route path="*">Error 404</Route>
-              </Switch>
-            </Router>
-          </ThemeProvider>
-        </StyledEngineProvider>
-      </QueryClientProvider>
-    </React.StrictMode>
-  )
-}
-
 ReactDOM.render(
-  <App />,
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <StyledEngineProvider injectFirst>
+        <DarkThemeProvider>
+          <CssBaseline />
+          <Router>
+            <Switch>
+              <Route path="/tt"><TTCount /></Route>
+              <Route path={['/', '/:place', '/:place/:day']} exact><PresencePage /></Route>
+              <Route path="/archives"><ArchivePage /></Route>
+              <Route path="*">Error 404</Route>
+            </Switch>
+          </Router>
+        </DarkThemeProvider>
+      </StyledEngineProvider>
+    </QueryClientProvider>
+  </React.StrictMode>,
   document.getElementById('root'),
 );


### PR DESCRIPTION
Ajout d'un thème sombre ainsi qu'un menu utilisateur pour contrôler l'affichage de ce thème (trois options possibles : Sombre, Clair ou bien suivre le thème système).

Par défaut si l'utilisateur n'a pas de préférence, on estime qu'il veut le thème "Système". Le choix du thème est stocké dans le local storage.

L'affichage du plan inverse simplement les couleurs pour avoir le thème sombre, ça marche bien sur le cas présent mais c'est à prendre en compte dans le cas de contributions avec d'autres plans.