### PR TITLE
Add database backward compatibility to presences period

### DIFF
--- a/src/components/PreferencesTri.jsx
+++ b/src/components/PreferencesTri.jsx
@@ -3,6 +3,7 @@ import createPersistedState from 'use-persisted-state';
 
 import { Done, Edit } from '@mui/icons-material';
 import { Box, Divider, IconButton, TextField } from '@mui/material';
+import { cleanTri } from '../helpers';
 
 const useTriState = createPersistedState('tri');
 
@@ -12,7 +13,7 @@ const PreferencesTri = () => {
   const [textValue, setTextValue] = React.useState(tri);
 
   const handleSubmit = () => {
-    if (!disableInput) setTri(textValue);
+    if (!disableInput) setTri(cleanTri(textValue));
     setDisableInput(!disableInput);
   };
 

--- a/src/components/SpotButton.jsx
+++ b/src/components/SpotButton.jsx
@@ -280,7 +280,7 @@ const SpotButton = ({
   const handleClick = p => {
     if (edit) { return null; }
 
-    if ((!isOccupied && !isLocked) || (triPeriod)) {
+    if ((!isOccupied && !isLocked) || triPeriod) {
       const [firstId, ...extraneous] = dayPresences
         ?.filter(({ tri: t }) => sameLowC(t, ownTri)) // Keep only own points
         .filter(({ spot: s }) => !isCumulativeSpot(s)) // Keep only non cumulative
@@ -321,7 +321,7 @@ const SpotButton = ({
     { item: 'Matinée uniquement', action: morningOnly, disabled: mornings.length > 0 },
     { item: 'Après-midi uniquement', action: afternoonOnly, disabled: afternoons.length > 0 },
     { item: 'separator', separator: true },
-    { item: 'Se désinscrire', action: unsubscribe, disabled: Boolean(!triPeriod) },
+    { item: 'Se désinscrire', action: unsubscribe, disabled: !triPeriod },
   ];
 
   const title = 'Réserver pour :';

--- a/src/components/SpotDialog.jsx
+++ b/src/components/SpotDialog.jsx
@@ -113,6 +113,8 @@ const SpotDialog = ({
     enableFavorite && defaultFavoriteSpot && displayFavorite ? defaultFavoriteSpot.Identifiant : ''
   ));
 
+  const isSelectedValueReserved = Object.keys(spotPresences).includes(selectedValue);
+
   const addDefaultSelect = () => {
     if (favoriteSpots.filter(({ Identifiant: spot }) => !spotPresences[spot]).length >= 1
         && displayFavorite
@@ -167,11 +169,15 @@ const SpotDialog = ({
 
   useEffect(() => {
     if (defaultFavoriteSpot && enableFavorite) {
-      setSelectedValue(defaultFavoriteSpot.Identifiant);
-    } else {
-      setSelectedValue('');
+      return setSelectedValue(defaultFavoriteSpot.Identifiant);
     }
-  }, [defaultFavoriteSpot, enableFavorite, periodPref]);
+
+    if (isSelectedValueReserved) {
+      return setSelectedValue('');
+    }
+
+    return null;
+  }, [defaultFavoriteSpot, enableFavorite, periodPref, isSelectedValueReserved]);
 
   const handleKeyDown = event => {
     if (event.keyCode === 27) {


### PR DESCRIPTION
# Fix

- **Rétrocompatibilité de la table présences**
Considère que les présences dont le champs `period` est `null` comme une présences d'une journée entière.

- **Remet au propre le trigramme saisie par l'utilisateur**
Retire les majuscules et/ou retire les espaces préfixant et suffixant le trigramme saisi depuis le menu utilisateur. 
